### PR TITLE
Feature/favorite-202407102027 | Favorite  CRUD 추가

### DIFF
--- a/src/main/java/com/schedule/share/infra/rdb/entity/FavoriteEntity.java
+++ b/src/main/java/com/schedule/share/infra/rdb/entity/FavoriteEntity.java
@@ -1,6 +1,6 @@
 package com.schedule.share.infra.rdb.entity;
 
-import jakarta.persistence.Column;
+import com.schedule.share.user.domain.Favorite;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
@@ -22,7 +22,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-@Builder(toBuilder = true)
+@Builder
 public class FavoriteEntity {
 
     @Id
@@ -43,4 +43,13 @@ public class FavoriteEntity {
 
     @CreatedDate
     private LocalDateTime createdAt;
+
+    public void updateFavoriteEntity(Favorite favoriteEntity) {
+        this.userId = favoriteEntity.getUserId();
+        this.scheduleId = favoriteEntity.getScheduleId();
+        this.calendarId = favoriteEntity.getCalendarId();
+        this.isAllday = favoriteEntity.isAllday();
+        this.scheduleStartDatetime = favoriteEntity.getScheduleStartDatetime();
+        this.scheduleEndDatetime = favoriteEntity.getScheduleEndDatetime();
+    }
 }

--- a/src/main/java/com/schedule/share/infra/rdb/entity/FavoriteEntity.java
+++ b/src/main/java/com/schedule/share/infra/rdb/entity/FavoriteEntity.java
@@ -1,6 +1,5 @@
 package com.schedule.share.infra.rdb.entity;
 
-import com.schedule.share.user.domain.Favorite;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
@@ -43,13 +42,4 @@ public class FavoriteEntity {
 
     @CreatedDate
     private LocalDateTime createdAt;
-
-    public void updateFavoriteEntity(Favorite favoriteEntity) {
-        this.userId = favoriteEntity.getUserId();
-        this.scheduleId = favoriteEntity.getScheduleId();
-        this.calendarId = favoriteEntity.getCalendarId();
-        this.isAllday = favoriteEntity.isAllday();
-        this.scheduleStartDatetime = favoriteEntity.getScheduleStartDatetime();
-        this.scheduleEndDatetime = favoriteEntity.getScheduleEndDatetime();
-    }
 }

--- a/src/main/java/com/schedule/share/infra/rdb/entity/FavoriteEntity.java
+++ b/src/main/java/com/schedule/share/infra/rdb/entity/FavoriteEntity.java
@@ -1,5 +1,6 @@
 package com.schedule.share.infra.rdb.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
@@ -34,7 +35,8 @@ public class FavoriteEntity {
 
     private long calendarId;
 
-    private boolean isAllday;
+    @Column(name = "is_allday")
+    private boolean allday;
 
     private LocalDateTime scheduleStartDatetime;
 

--- a/src/main/java/com/schedule/share/infra/rdb/entity/FavoriteEntity.java
+++ b/src/main/java/com/schedule/share/infra/rdb/entity/FavoriteEntity.java
@@ -1,0 +1,45 @@
+package com.schedule.share.infra.rdb.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Table(catalog = "schedule", name = "favorite_schedule")
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder(toBuilder = true)
+public class FavoriteEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    private long userId;
+
+    private long scheduleId;
+
+    private long calendarId;
+
+    private int isAllday;
+
+    private LocalDateTime scheduleStartDatetime;
+
+    private LocalDateTime scheduleEndDatetime;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/schedule/share/infra/rdb/entity/FavoriteEntity.java
+++ b/src/main/java/com/schedule/share/infra/rdb/entity/FavoriteEntity.java
@@ -35,8 +35,7 @@ public class FavoriteEntity {
 
     private long calendarId;
 
-    @Column(name = "is_allday")
-    private boolean allday;
+    private boolean isAllday;
 
     private LocalDateTime scheduleStartDatetime;
 

--- a/src/main/java/com/schedule/share/infra/rdb/entity/FavoriteEntity.java
+++ b/src/main/java/com/schedule/share/infra/rdb/entity/FavoriteEntity.java
@@ -34,7 +34,7 @@ public class FavoriteEntity {
 
     private long calendarId;
 
-    private int isAllday;
+    private boolean isAllday;
 
     private LocalDateTime scheduleStartDatetime;
 

--- a/src/main/java/com/schedule/share/infra/rdb/repository/FavoriteRepository.java
+++ b/src/main/java/com/schedule/share/infra/rdb/repository/FavoriteRepository.java
@@ -1,0 +1,9 @@
+package com.schedule.share.infra.rdb.repository;
+
+import com.schedule.share.infra.rdb.entity.FavoriteEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FavoriteRepository extends JpaRepository<FavoriteEntity, Long> {
+}

--- a/src/main/java/com/schedule/share/user/adaptor/inbound/api/FavoriteApi.java
+++ b/src/main/java/com/schedule/share/user/adaptor/inbound/api/FavoriteApi.java
@@ -1,0 +1,68 @@
+package com.schedule.share.user.adaptor.inbound.api;
+
+import com.schedule.share.user.adaptor.inbound.api.dto.FavoriteRequestDTO;
+import com.schedule.share.user.adaptor.inbound.api.dto.FavoriteResponseDTO;
+import com.schedule.share.user.adaptor.inbound.api.mapper.FavoriteDTOMapper;
+import com.schedule.share.user.application.port.inbound.FavoriteCommand;
+import com.schedule.share.user.application.port.inbound.FavoriteQuery;
+import com.schedule.share.user.application.service.user.FavoriteService;
+import com.schedule.share.user.application.service.user.vo.FavoriteVO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "즐겨찾기", description = "즐겨찾기 API")
+@RestController
+@RequestMapping("/favorite")
+@RequiredArgsConstructor
+public class FavoriteApi {
+
+    private final FavoriteCommand favoriteCommand;
+    private final FavoriteQuery favoriteQuery;
+    private final FavoriteService favoriteService;
+
+    @Operation(summary = "즐겨찾기 추가 API", description = "즐겨찾기를 추가한다.")
+    @PostMapping
+    public void create(@RequestBody FavoriteRequestDTO.Favorite body) {
+        favoriteCommand.create(FavoriteDTOMapper.INSTANCE.toVo(body));
+    }
+
+    @Operation(summary = "즐겨찾기 단일 조회 API", description = "즐겨찾기를 하나 조회한다.")
+    @GetMapping("/{id}")
+    public FavoriteResponseDTO.Response get(@PathVariable long id) {
+        FavoriteVO.Favorite favorite = favoriteQuery.get(id);
+
+        return FavoriteDTOMapper.INSTANCE.toResponseDTO(favorite);
+    }
+
+    @Operation(summary = "즐겨찾기 모두 조회 API", description = "즐겨찾기를 모두 조회한다.")
+    @GetMapping
+    public List<FavoriteResponseDTO.Response> getList() {
+        List<FavoriteVO.Favorite> list = favoriteQuery.list();
+
+        return list.stream().map(FavoriteDTOMapper.INSTANCE::toResponseDTO).toList();
+    }
+
+    @Operation(summary = "즐겨찾기 수정 API", description = "즐겨찾기를 수정한다.")
+    @PutMapping("/{id}")
+    public void update(@PathVariable long id, @RequestBody FavoriteRequestDTO.Favorite body) {
+        favoriteCommand.update(id, FavoriteDTOMapper.INSTANCE.toVo(body));
+    }
+
+    @Operation(summary = "즐겨찾기 삭제 API", description = "즐겨찾기를 하나 조회한다.")
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable long id) {
+        favoriteCommand.delete(id);
+    }
+}

--- a/src/main/java/com/schedule/share/user/adaptor/inbound/api/FavoriteApi.java
+++ b/src/main/java/com/schedule/share/user/adaptor/inbound/api/FavoriteApi.java
@@ -7,6 +7,7 @@ import com.schedule.share.user.application.port.inbound.FavoriteCommand;
 import com.schedule.share.user.application.port.inbound.FavoriteQuery;
 import com.schedule.share.user.application.service.user.FavoriteService;
 import com.schedule.share.user.application.service.user.vo.FavoriteVO;
+import com.schedule.share.user.domain.mapper.FavoriteMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -30,12 +31,13 @@ public class FavoriteApi {
 
     private final FavoriteCommand favoriteCommand;
     private final FavoriteQuery favoriteQuery;
+    private final FavoriteDTOMapper favoriteDTOMapper;
     private final FavoriteService favoriteService;
 
     @Operation(summary = "즐겨찾기 추가 API", description = "즐겨찾기를 추가한다.")
     @PostMapping
     public void create(@RequestBody FavoriteRequestDTO.Favorite body) {
-        favoriteCommand.create(FavoriteDTOMapper.INSTANCE.toVo(body));
+        favoriteCommand.create(favoriteDTOMapper.toVo(body));
     }
 
     @Operation(summary = "즐겨찾기 단일 조회 API", description = "즐겨찾기를 하나 조회한다.")
@@ -43,7 +45,7 @@ public class FavoriteApi {
     public FavoriteResponseDTO.Response get(@PathVariable long id) {
         FavoriteVO.Favorite favorite = favoriteQuery.get(id);
 
-        return FavoriteDTOMapper.INSTANCE.toResponseDTO(favorite);
+        return favoriteDTOMapper.toResponseDTO(favorite);
     }
 
     @Operation(summary = "즐겨찾기 모두 조회 API", description = "즐겨찾기를 모두 조회한다.")
@@ -51,13 +53,13 @@ public class FavoriteApi {
     public List<FavoriteResponseDTO.Response> getList() {
         List<FavoriteVO.Favorite> list = favoriteQuery.list();
 
-        return list.stream().map(FavoriteDTOMapper.INSTANCE::toResponseDTO).toList();
+        return list.stream().map(favoriteDTOMapper::toResponseDTO).toList();
     }
 
     @Operation(summary = "즐겨찾기 수정 API", description = "즐겨찾기를 수정한다.")
     @PutMapping("/{id}")
     public void update(@PathVariable long id, @RequestBody FavoriteRequestDTO.Favorite body) {
-        favoriteCommand.update(id, FavoriteDTOMapper.INSTANCE.toVo(body));
+        favoriteCommand.update(id, favoriteDTOMapper.toVo(body));
     }
 
     @Operation(summary = "즐겨찾기 삭제 API", description = "즐겨찾기를 하나 조회한다.")

--- a/src/main/java/com/schedule/share/user/adaptor/inbound/api/FavoriteApi.java
+++ b/src/main/java/com/schedule/share/user/adaptor/inbound/api/FavoriteApi.java
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -54,15 +53,15 @@ public class FavoriteApi {
         return list.stream().map(favoriteDTOMapper::toResponseDTO).toList();
     }
 
-    @Operation(summary = "즐겨찾기 수정 API", description = "즐겨찾기를 수정한다.")
-    @PutMapping("/{id}")
-    public void update(@PathVariable long id, @RequestBody FavoriteRequestDTO.Favorite body) {
-        favoriteCommand.update(id, favoriteDTOMapper.toVo(body));
+    @Operation(summary = "즐겨찾기 삭제 API", description = "즐겨찾기를 삭제한다.")
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable long id) {
+        favoriteCommand.delete(id);
     }
 
-    @Operation(summary = "즐겨찾기 삭제 API", description = "즐겨찾기를 삭제한다.")
-    @DeleteMapping("/{ids}")
-    public void delete(@PathVariable List<Long> ids) {
-        favoriteCommand.delete(ids);
+    @Operation(summary = "즐겨찾기들 삭제 API", description = "즐겨찾기들을 삭제한다.")
+    @DeleteMapping
+    public void bulkDelete(@RequestBody FavoriteRequestDTO.BulkDelete bulkDelete) {
+        favoriteCommand.delete(bulkDelete.list());
     }
 }

--- a/src/main/java/com/schedule/share/user/adaptor/inbound/api/FavoriteApi.java
+++ b/src/main/java/com/schedule/share/user/adaptor/inbound/api/FavoriteApi.java
@@ -7,7 +7,6 @@ import com.schedule.share.user.application.port.inbound.FavoriteCommand;
 import com.schedule.share.user.application.port.inbound.FavoriteQuery;
 import com.schedule.share.user.application.service.user.FavoriteService;
 import com.schedule.share.user.application.service.user.vo.FavoriteVO;
-import com.schedule.share.user.domain.mapper.FavoriteMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -18,14 +17,13 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @Tag(name = "즐겨찾기", description = "즐겨찾기 API")
 @RestController
-@RequestMapping("/favorite")
+@RequestMapping("/favorites")
 @RequiredArgsConstructor
 public class FavoriteApi {
 
@@ -62,9 +60,9 @@ public class FavoriteApi {
         favoriteCommand.update(id, favoriteDTOMapper.toVo(body));
     }
 
-    @Operation(summary = "즐겨찾기 삭제 API", description = "즐겨찾기를 하나 조회한다.")
-    @DeleteMapping("/{id}")
-    public void delete(@PathVariable long id) {
-        favoriteCommand.delete(id);
+    @Operation(summary = "즐겨찾기 삭제 API", description = "즐겨찾기를 삭제한다.")
+    @DeleteMapping("/{ids}")
+    public void delete(@PathVariable List<Long> ids) {
+        favoriteCommand.delete(ids);
     }
 }

--- a/src/main/java/com/schedule/share/user/adaptor/inbound/api/dto/FavoriteRequestDTO.java
+++ b/src/main/java/com/schedule/share/user/adaptor/inbound/api/dto/FavoriteRequestDTO.java
@@ -8,7 +8,7 @@ public class FavoriteRequestDTO {
             long userId,
             long scheduleId,
             long calendarId,
-            int isAllday,
+            boolean isAllday,
             LocalDateTime scheduleStartDatetime,
             LocalDateTime scheduleEndDatetime
     ) {

--- a/src/main/java/com/schedule/share/user/adaptor/inbound/api/dto/FavoriteRequestDTO.java
+++ b/src/main/java/com/schedule/share/user/adaptor/inbound/api/dto/FavoriteRequestDTO.java
@@ -8,7 +8,7 @@ public class FavoriteRequestDTO {
             long userId,
             long scheduleId,
             long calendarId,
-            boolean isAllday,
+            boolean allday,
             LocalDateTime scheduleStartDatetime,
             LocalDateTime scheduleEndDatetime
     ) {

--- a/src/main/java/com/schedule/share/user/adaptor/inbound/api/dto/FavoriteRequestDTO.java
+++ b/src/main/java/com/schedule/share/user/adaptor/inbound/api/dto/FavoriteRequestDTO.java
@@ -1,0 +1,16 @@
+package com.schedule.share.user.adaptor.inbound.api.dto;
+
+import java.time.LocalDateTime;
+
+public class FavoriteRequestDTO {
+
+    public record Favorite(
+            long userId,
+            long scheduleId,
+            long calendarId,
+            int isAllday,
+            LocalDateTime scheduleStartDatetime,
+            LocalDateTime scheduleEndDatetime
+    ) {
+    }
+}

--- a/src/main/java/com/schedule/share/user/adaptor/inbound/api/dto/FavoriteRequestDTO.java
+++ b/src/main/java/com/schedule/share/user/adaptor/inbound/api/dto/FavoriteRequestDTO.java
@@ -1,6 +1,7 @@
 package com.schedule.share.user.adaptor.inbound.api.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class FavoriteRequestDTO {
 
@@ -11,6 +12,11 @@ public class FavoriteRequestDTO {
             boolean isAllday,
             LocalDateTime scheduleStartDatetime,
             LocalDateTime scheduleEndDatetime
+    ) {
+    }
+
+    public record BulkDelete(
+            List<Long> list
     ) {
     }
 }

--- a/src/main/java/com/schedule/share/user/adaptor/inbound/api/dto/FavoriteRequestDTO.java
+++ b/src/main/java/com/schedule/share/user/adaptor/inbound/api/dto/FavoriteRequestDTO.java
@@ -8,7 +8,7 @@ public class FavoriteRequestDTO {
             long userId,
             long scheduleId,
             long calendarId,
-            boolean allday,
+            boolean isAllday,
             LocalDateTime scheduleStartDatetime,
             LocalDateTime scheduleEndDatetime
     ) {

--- a/src/main/java/com/schedule/share/user/adaptor/inbound/api/dto/FavoriteResponseDTO.java
+++ b/src/main/java/com/schedule/share/user/adaptor/inbound/api/dto/FavoriteResponseDTO.java
@@ -12,7 +12,7 @@ public class FavoriteResponseDTO {
             long userId,
             long scheduleId,
             long calendarId,
-            boolean isAllday,
+            boolean allday,
             LocalDateTime scheduleStartDatetime,
             LocalDateTime scheduleEndDatetime,
             LocalDateTime createdAt

--- a/src/main/java/com/schedule/share/user/adaptor/inbound/api/dto/FavoriteResponseDTO.java
+++ b/src/main/java/com/schedule/share/user/adaptor/inbound/api/dto/FavoriteResponseDTO.java
@@ -12,7 +12,7 @@ public class FavoriteResponseDTO {
             long userId,
             long scheduleId,
             long calendarId,
-            boolean allday,
+            boolean isAllday,
             LocalDateTime scheduleStartDatetime,
             LocalDateTime scheduleEndDatetime,
             LocalDateTime createdAt

--- a/src/main/java/com/schedule/share/user/adaptor/inbound/api/dto/FavoriteResponseDTO.java
+++ b/src/main/java/com/schedule/share/user/adaptor/inbound/api/dto/FavoriteResponseDTO.java
@@ -1,0 +1,21 @@
+package com.schedule.share.user.adaptor.inbound.api.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+public class FavoriteResponseDTO {
+
+    @Builder
+    public record Response(
+            long id,
+            long userId,
+            long scheduleId,
+            long calendarId,
+            int isAllday,
+            LocalDateTime scheduleStartDatetime,
+            LocalDateTime scheduleEndDatetime,
+            LocalDateTime createdAt
+    ) {
+    }
+}

--- a/src/main/java/com/schedule/share/user/adaptor/inbound/api/dto/FavoriteResponseDTO.java
+++ b/src/main/java/com/schedule/share/user/adaptor/inbound/api/dto/FavoriteResponseDTO.java
@@ -12,7 +12,7 @@ public class FavoriteResponseDTO {
             long userId,
             long scheduleId,
             long calendarId,
-            int isAllday,
+            boolean isAllday,
             LocalDateTime scheduleStartDatetime,
             LocalDateTime scheduleEndDatetime,
             LocalDateTime createdAt

--- a/src/main/java/com/schedule/share/user/adaptor/inbound/api/mapper/FavoriteDTOMapper.java
+++ b/src/main/java/com/schedule/share/user/adaptor/inbound/api/mapper/FavoriteDTOMapper.java
@@ -4,12 +4,9 @@ import com.schedule.share.user.adaptor.inbound.api.dto.FavoriteRequestDTO;
 import com.schedule.share.user.adaptor.inbound.api.dto.FavoriteResponseDTO;
 import com.schedule.share.user.application.service.user.vo.FavoriteVO;
 import org.mapstruct.Mapper;
-import org.mapstruct.factory.Mappers;
 
-@Mapper
+@Mapper(componentModel = "spring")
 public interface FavoriteDTOMapper {
-
-    FavoriteDTOMapper INSTANCE = Mappers.getMapper(FavoriteDTOMapper.class);
 
     FavoriteVO.save toVo(FavoriteRequestDTO.Favorite favoriteRequestDTO);
 

--- a/src/main/java/com/schedule/share/user/adaptor/inbound/api/mapper/FavoriteDTOMapper.java
+++ b/src/main/java/com/schedule/share/user/adaptor/inbound/api/mapper/FavoriteDTOMapper.java
@@ -1,0 +1,17 @@
+package com.schedule.share.user.adaptor.inbound.api.mapper;
+
+import com.schedule.share.user.adaptor.inbound.api.dto.FavoriteRequestDTO;
+import com.schedule.share.user.adaptor.inbound.api.dto.FavoriteResponseDTO;
+import com.schedule.share.user.application.service.user.vo.FavoriteVO;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface FavoriteDTOMapper {
+
+    FavoriteDTOMapper INSTANCE = Mappers.getMapper(FavoriteDTOMapper.class);
+
+    FavoriteVO.save toVo(FavoriteRequestDTO.Favorite favoriteRequestDTO);
+
+    FavoriteResponseDTO.Response toResponseDTO(FavoriteVO.Favorite favorite);
+}

--- a/src/main/java/com/schedule/share/user/adaptor/inbound/api/mapper/FavoriteDTOMapper.java
+++ b/src/main/java/com/schedule/share/user/adaptor/inbound/api/mapper/FavoriteDTOMapper.java
@@ -11,4 +11,5 @@ public interface FavoriteDTOMapper {
     FavoriteVO.save toVo(FavoriteRequestDTO.Favorite favoriteRequestDTO);
 
     FavoriteResponseDTO.Response toResponseDTO(FavoriteVO.Favorite favorite);
+
 }

--- a/src/main/java/com/schedule/share/user/adaptor/outbound/FavoriteCommandAdaptor.java
+++ b/src/main/java/com/schedule/share/user/adaptor/outbound/FavoriteCommandAdaptor.java
@@ -5,10 +5,12 @@ import com.schedule.share.infra.rdb.repository.FavoriteRepository;
 import com.schedule.share.user.application.port.outbound.FavoriteCommandPort;
 import com.schedule.share.user.domain.Favorite;
 import com.schedule.share.user.domain.mapper.FavoriteMapper;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@Transactional
 @RequiredArgsConstructor
 public class FavoriteCommandAdaptor implements FavoriteCommandPort {
 
@@ -26,13 +28,7 @@ public class FavoriteCommandAdaptor implements FavoriteCommandPort {
     public void update(long id, Favorite param) {
         FavoriteEntity favoriteEntity = favoriteRepository.findById(id).orElseThrow();
 
-        FavoriteEntity result = favoriteEntity.toBuilder()
-                .isAllday(param.isAllday())
-                .scheduleStartDatetime(param.getScheduleStartDatetime())
-                .scheduleEndDatetime(param.getScheduleEndDatetime())
-                .build();
-
-        favoriteRepository.save(result);
+        favoriteEntity.updateFavoriteEntity(param);
     }
 
     @Override

--- a/src/main/java/com/schedule/share/user/adaptor/outbound/FavoriteCommandAdaptor.java
+++ b/src/main/java/com/schedule/share/user/adaptor/outbound/FavoriteCommandAdaptor.java
@@ -8,8 +8,6 @@ import com.schedule.share.user.domain.mapper.FavoriteMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
-
 @Component
 @RequiredArgsConstructor
 public class FavoriteCommandAdaptor implements FavoriteCommandPort {
@@ -25,11 +23,10 @@ public class FavoriteCommandAdaptor implements FavoriteCommandPort {
 
     @Override
     public void update(long id, Favorite param) {
-        FavoriteEntity result = FavoriteMapper.INSTANCE.favoriteToEntity(param).toBuilder()
-                .userId(param.getUserId())
-                .scheduleId(param.getScheduleId())
-                .calendarId(param.getCalendarId())
-                .isAllday(param.getIsAllday())
+        FavoriteEntity favoriteEntity = favoriteRepository.findById(id).orElseThrow();
+
+        FavoriteEntity result = favoriteEntity.toBuilder()
+                .isAllday(param.isAllday())
                 .scheduleStartDatetime(param.getScheduleStartDatetime())
                 .scheduleEndDatetime(param.getScheduleEndDatetime())
                 .build();

--- a/src/main/java/com/schedule/share/user/adaptor/outbound/FavoriteCommandAdaptor.java
+++ b/src/main/java/com/schedule/share/user/adaptor/outbound/FavoriteCommandAdaptor.java
@@ -28,13 +28,11 @@ public class FavoriteCommandAdaptor implements FavoriteCommandPort {
 
     @Override
     public void update(long id, Favorite param) {
-        FavoriteEntity favoriteEntity = favoriteRepository.findById(id).orElseThrow();
-
-        favoriteEntity.updateFavoriteEntity(param);
     }
 
     @Override
     public void delete(long id) {
+        favoriteRepository.deleteById(id);
     }
 
     @Override

--- a/src/main/java/com/schedule/share/user/adaptor/outbound/FavoriteCommandAdaptor.java
+++ b/src/main/java/com/schedule/share/user/adaptor/outbound/FavoriteCommandAdaptor.java
@@ -1,0 +1,44 @@
+package com.schedule.share.user.adaptor.outbound;
+
+import com.schedule.share.infra.rdb.entity.FavoriteEntity;
+import com.schedule.share.infra.rdb.repository.FavoriteRepository;
+import com.schedule.share.user.application.port.outbound.FavoriteCommandPort;
+import com.schedule.share.user.domain.Favorite;
+import com.schedule.share.user.domain.mapper.FavoriteMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class FavoriteCommandAdaptor implements FavoriteCommandPort {
+
+    private final FavoriteRepository favoriteRepository;
+
+    @Override
+    public long create(Favorite param) {
+        FavoriteEntity favoriteEntity = FavoriteMapper.INSTANCE.favoriteToEntity(param);
+
+        return favoriteRepository.save(favoriteEntity).getId();
+    }
+
+    @Override
+    public void update(long id, Favorite param) {
+        FavoriteEntity result = FavoriteMapper.INSTANCE.favoriteToEntity(param).toBuilder()
+                .userId(param.getUserId())
+                .scheduleId(param.getScheduleId())
+                .calendarId(param.getCalendarId())
+                .isAllday(param.getIsAllday())
+                .scheduleStartDatetime(param.getScheduleStartDatetime())
+                .scheduleEndDatetime(param.getScheduleEndDatetime())
+                .build();
+
+        favoriteRepository.save(result);
+    }
+
+    @Override
+    public void delete(long id) {
+        favoriteRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/schedule/share/user/adaptor/outbound/FavoriteCommandAdaptor.java
+++ b/src/main/java/com/schedule/share/user/adaptor/outbound/FavoriteCommandAdaptor.java
@@ -13,10 +13,11 @@ import org.springframework.stereotype.Component;
 public class FavoriteCommandAdaptor implements FavoriteCommandPort {
 
     private final FavoriteRepository favoriteRepository;
+    private final FavoriteMapper favoriteMapper;
 
     @Override
     public long create(Favorite param) {
-        FavoriteEntity favoriteEntity = FavoriteMapper.INSTANCE.favoriteToEntity(param);
+        FavoriteEntity favoriteEntity = favoriteMapper.favoriteToEntity(param);
 
         return favoriteRepository.save(favoriteEntity).getId();
     }

--- a/src/main/java/com/schedule/share/user/adaptor/outbound/FavoriteCommandAdaptor.java
+++ b/src/main/java/com/schedule/share/user/adaptor/outbound/FavoriteCommandAdaptor.java
@@ -27,10 +27,6 @@ public class FavoriteCommandAdaptor implements FavoriteCommandPort {
     }
 
     @Override
-    public void update(long id, Favorite param) {
-    }
-
-    @Override
     public void delete(long id) {
         favoriteRepository.deleteById(id);
     }

--- a/src/main/java/com/schedule/share/user/adaptor/outbound/FavoriteCommandAdaptor.java
+++ b/src/main/java/com/schedule/share/user/adaptor/outbound/FavoriteCommandAdaptor.java
@@ -26,7 +26,7 @@ public class FavoriteCommandAdaptor implements FavoriteCommandPort {
         FavoriteEntity favoriteEntity = favoriteRepository.findById(id).orElseThrow();
 
         FavoriteEntity result = favoriteEntity.toBuilder()
-                .allday(param.isAllday())
+                .isAllday(param.isAllday())
                 .scheduleStartDatetime(param.getScheduleStartDatetime())
                 .scheduleEndDatetime(param.getScheduleEndDatetime())
                 .build();

--- a/src/main/java/com/schedule/share/user/adaptor/outbound/FavoriteCommandAdaptor.java
+++ b/src/main/java/com/schedule/share/user/adaptor/outbound/FavoriteCommandAdaptor.java
@@ -26,7 +26,7 @@ public class FavoriteCommandAdaptor implements FavoriteCommandPort {
         FavoriteEntity favoriteEntity = favoriteRepository.findById(id).orElseThrow();
 
         FavoriteEntity result = favoriteEntity.toBuilder()
-                .isAllday(param.isAllday())
+                .allday(param.isAllday())
                 .scheduleStartDatetime(param.getScheduleStartDatetime())
                 .scheduleEndDatetime(param.getScheduleEndDatetime())
                 .build();

--- a/src/main/java/com/schedule/share/user/adaptor/outbound/FavoriteCommandAdaptor.java
+++ b/src/main/java/com/schedule/share/user/adaptor/outbound/FavoriteCommandAdaptor.java
@@ -9,6 +9,8 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 @Transactional
 @RequiredArgsConstructor
@@ -33,6 +35,11 @@ public class FavoriteCommandAdaptor implements FavoriteCommandPort {
 
     @Override
     public void delete(long id) {
-        favoriteRepository.deleteById(id);
     }
+
+    @Override
+    public void delete(List<Long> ids) {
+        favoriteRepository.deleteAllById(ids);
+    }
+
 }

--- a/src/main/java/com/schedule/share/user/adaptor/outbound/FavoriteQueryAdaptor.java
+++ b/src/main/java/com/schedule/share/user/adaptor/outbound/FavoriteQueryAdaptor.java
@@ -1,0 +1,32 @@
+package com.schedule.share.user.adaptor.outbound;
+
+import com.schedule.share.infra.rdb.entity.FavoriteEntity;
+import com.schedule.share.infra.rdb.repository.FavoriteRepository;
+import com.schedule.share.user.application.port.outbound.FavoriteQueryPort;
+import com.schedule.share.user.domain.Favorite;
+import com.schedule.share.user.domain.mapper.FavoriteMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class FavoriteQueryAdaptor implements FavoriteQueryPort {
+
+    private final FavoriteRepository favoriteRepository;
+
+    @Override
+    public Favorite get(long id) {
+        FavoriteEntity favoriteEntity = favoriteRepository.findById(id).orElseThrow();
+
+        return FavoriteMapper.INSTANCE.favoriteEntityToDomain(favoriteEntity);
+    }
+
+    @Override
+    public List<Favorite> list() {
+        return favoriteRepository.findAll().stream().map(
+                FavoriteMapper.INSTANCE::favoriteEntityToDomain
+        ).toList();
+    }
+}

--- a/src/main/java/com/schedule/share/user/adaptor/outbound/FavoriteQueryAdaptor.java
+++ b/src/main/java/com/schedule/share/user/adaptor/outbound/FavoriteQueryAdaptor.java
@@ -15,18 +15,19 @@ import java.util.List;
 public class FavoriteQueryAdaptor implements FavoriteQueryPort {
 
     private final FavoriteRepository favoriteRepository;
+    private final FavoriteMapper favoriteMapper;
 
     @Override
     public Favorite get(long id) {
         FavoriteEntity favoriteEntity = favoriteRepository.findById(id).orElseThrow();
 
-        return FavoriteMapper.INSTANCE.favoriteEntityToDomain(favoriteEntity);
+        return favoriteMapper.favoriteEntityToDomain(favoriteEntity);
     }
 
     @Override
     public List<Favorite> list() {
         return favoriteRepository.findAll().stream().map(
-                FavoriteMapper.INSTANCE::favoriteEntityToDomain
+                favoriteMapper::favoriteEntityToDomain
         ).toList();
     }
 }

--- a/src/main/java/com/schedule/share/user/application/port/inbound/FavoriteCommand.java
+++ b/src/main/java/com/schedule/share/user/application/port/inbound/FavoriteCommand.java
@@ -3,5 +3,8 @@ package com.schedule.share.user.application.port.inbound;
 import com.schedule.share.user.application.service.DomainCommand;
 import com.schedule.share.user.application.service.user.vo.FavoriteVO;
 
+import java.util.List;
+
 public interface FavoriteCommand extends DomainCommand<FavoriteVO.save> {
+    void delete(List<Long> ids);
 }

--- a/src/main/java/com/schedule/share/user/application/port/inbound/FavoriteCommand.java
+++ b/src/main/java/com/schedule/share/user/application/port/inbound/FavoriteCommand.java
@@ -1,0 +1,7 @@
+package com.schedule.share.user.application.port.inbound;
+
+import com.schedule.share.user.application.service.DomainCommand;
+import com.schedule.share.user.application.service.user.vo.FavoriteVO;
+
+public interface FavoriteCommand extends DomainCommand<FavoriteVO.save> {
+}

--- a/src/main/java/com/schedule/share/user/application/port/inbound/FavoriteCommand.java
+++ b/src/main/java/com/schedule/share/user/application/port/inbound/FavoriteCommand.java
@@ -1,10 +1,14 @@
 package com.schedule.share.user.application.port.inbound;
 
-import com.schedule.share.user.application.service.DomainCommand;
 import com.schedule.share.user.application.service.user.vo.FavoriteVO;
 
 import java.util.List;
 
-public interface FavoriteCommand extends DomainCommand<FavoriteVO.save> {
+public interface FavoriteCommand {
+
+    long create(FavoriteVO.save param);
+
+    void delete(long id);
+
     void delete(List<Long> ids);
 }

--- a/src/main/java/com/schedule/share/user/application/port/inbound/FavoriteQuery.java
+++ b/src/main/java/com/schedule/share/user/application/port/inbound/FavoriteQuery.java
@@ -1,0 +1,7 @@
+package com.schedule.share.user.application.port.inbound;
+
+import com.schedule.share.user.application.service.DomainQuery;
+import com.schedule.share.user.application.service.user.vo.FavoriteVO;
+
+public interface FavoriteQuery extends DomainQuery<FavoriteVO.Favorite> {
+}

--- a/src/main/java/com/schedule/share/user/application/port/outbound/FavoriteCommandPort.java
+++ b/src/main/java/com/schedule/share/user/application/port/outbound/FavoriteCommandPort.java
@@ -3,5 +3,8 @@ package com.schedule.share.user.application.port.outbound;
 import com.schedule.share.user.application.service.DomainCommand;
 import com.schedule.share.user.domain.Favorite;
 
-public interface FavoriteCommandPort extends DomainCommand<Favorite> {
+import java.util.List;
+
+public interface FavoriteCommandPort extends DomainCommand<Favorite>{
+    void delete(List<Long> ids);
 }

--- a/src/main/java/com/schedule/share/user/application/port/outbound/FavoriteCommandPort.java
+++ b/src/main/java/com/schedule/share/user/application/port/outbound/FavoriteCommandPort.java
@@ -1,0 +1,7 @@
+package com.schedule.share.user.application.port.outbound;
+
+import com.schedule.share.user.application.service.DomainCommand;
+import com.schedule.share.user.domain.Favorite;
+
+public interface FavoriteCommandPort extends DomainCommand<Favorite> {
+}

--- a/src/main/java/com/schedule/share/user/application/port/outbound/FavoriteCommandPort.java
+++ b/src/main/java/com/schedule/share/user/application/port/outbound/FavoriteCommandPort.java
@@ -1,10 +1,14 @@
 package com.schedule.share.user.application.port.outbound;
 
-import com.schedule.share.user.application.service.DomainCommand;
 import com.schedule.share.user.domain.Favorite;
 
 import java.util.List;
 
-public interface FavoriteCommandPort extends DomainCommand<Favorite>{
+public interface FavoriteCommandPort {
+
+    long create(Favorite param);
+
+    void delete(long id);
+
     void delete(List<Long> ids);
 }

--- a/src/main/java/com/schedule/share/user/application/port/outbound/FavoriteQueryPort.java
+++ b/src/main/java/com/schedule/share/user/application/port/outbound/FavoriteQueryPort.java
@@ -1,0 +1,7 @@
+package com.schedule.share.user.application.port.outbound;
+
+import com.schedule.share.user.application.service.DomainQuery;
+import com.schedule.share.user.domain.Favorite;
+
+public interface FavoriteQueryPort extends DomainQuery<Favorite> {
+}

--- a/src/main/java/com/schedule/share/user/application/service/DomainCommand.java
+++ b/src/main/java/com/schedule/share/user/application/service/DomainCommand.java
@@ -7,5 +7,4 @@ public interface DomainCommand<R> {
     void update(long id, R param);
 
     void delete(long id);
-
 }

--- a/src/main/java/com/schedule/share/user/application/service/user/FavoriteReader.java
+++ b/src/main/java/com/schedule/share/user/application/service/user/FavoriteReader.java
@@ -16,19 +16,19 @@ import java.util.List;
 public class FavoriteReader implements FavoriteQuery {
 
     private final FavoriteQueryPort favoriteQueryPort;
-
+    private final FavoriteMapper favoriteMapper;
 
     @Override
     public FavoriteVO.Favorite get(long id) {
         Favorite favorite = favoriteQueryPort.get(id);
 
-        return FavoriteMapper.INSTANCE.favoriteToVO(favorite);
+        return favoriteMapper.favoriteToVO(favorite);
     }
 
     @Override
     public List<FavoriteVO.Favorite> list() {
         List<Favorite> list = favoriteQueryPort.list();
 
-        return list.stream().map(FavoriteMapper.INSTANCE::favoriteToVO).toList();
+        return list.stream().map(favoriteMapper::favoriteToVO).toList();
     }
 }

--- a/src/main/java/com/schedule/share/user/application/service/user/FavoriteReader.java
+++ b/src/main/java/com/schedule/share/user/application/service/user/FavoriteReader.java
@@ -1,0 +1,34 @@
+package com.schedule.share.user.application.service.user;
+
+import com.schedule.share.infra.rdb.entity.FavoriteEntity;
+import com.schedule.share.user.application.port.inbound.FavoriteQuery;
+import com.schedule.share.user.application.port.outbound.FavoriteQueryPort;
+import com.schedule.share.user.application.service.user.vo.FavoriteVO;
+import com.schedule.share.user.domain.Favorite;
+import com.schedule.share.user.domain.mapper.FavoriteMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FavoriteReader implements FavoriteQuery {
+
+    private final FavoriteQueryPort favoriteQueryPort;
+
+
+    @Override
+    public FavoriteVO.Favorite get(long id) {
+        Favorite favorite = favoriteQueryPort.get(id);
+
+        return FavoriteMapper.INSTANCE.favoriteToVO(favorite);
+    }
+
+    @Override
+    public List<FavoriteVO.Favorite> list() {
+        List<Favorite> list = favoriteQueryPort.list();
+
+        return list.stream().map(FavoriteMapper.INSTANCE::favoriteToVO).toList();
+    }
+}

--- a/src/main/java/com/schedule/share/user/application/service/user/FavoriteService.java
+++ b/src/main/java/com/schedule/share/user/application/service/user/FavoriteService.java
@@ -1,0 +1,14 @@
+package com.schedule.share.user.application.service.user;
+
+import com.schedule.share.user.application.port.outbound.FavoriteCommandPort;
+import com.schedule.share.user.application.port.outbound.FavoriteQueryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FavoriteService {
+
+    private final FavoriteQueryPort favoriteQueryPort;
+    private final FavoriteCommandPort favoriteCommandPort;
+}

--- a/src/main/java/com/schedule/share/user/application/service/user/FavoriteWriter.java
+++ b/src/main/java/com/schedule/share/user/application/service/user/FavoriteWriter.java
@@ -12,15 +12,16 @@ import org.springframework.stereotype.Service;
 public class FavoriteWriter implements FavoriteCommand {
 
     private final FavoriteCommandPort favoriteCommandPort;
+    private final FavoriteMapper favoriteMapper;
 
     @Override
     public long create(FavoriteVO.save param) {
-        return favoriteCommandPort.create(FavoriteMapper.INSTANCE.favoriteVoSaveToDomain(param));
+        return favoriteCommandPort.create(favoriteMapper.favoriteVoSaveToDomain(param));
     }
 
     @Override
     public void update(long id, FavoriteVO.save param) {
-        favoriteCommandPort.update(id, FavoriteMapper.INSTANCE.favoriteVoSaveToDomain(param));
+        favoriteCommandPort.update(id, favoriteMapper.favoriteVoSaveToDomain(param));
     }
 
     @Override

--- a/src/main/java/com/schedule/share/user/application/service/user/FavoriteWriter.java
+++ b/src/main/java/com/schedule/share/user/application/service/user/FavoriteWriter.java
@@ -1,0 +1,30 @@
+package com.schedule.share.user.application.service.user;
+
+import com.schedule.share.user.application.port.inbound.FavoriteCommand;
+import com.schedule.share.user.application.port.outbound.FavoriteCommandPort;
+import com.schedule.share.user.application.service.user.vo.FavoriteVO;
+import com.schedule.share.user.domain.mapper.FavoriteMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FavoriteWriter implements FavoriteCommand {
+
+    private final FavoriteCommandPort favoriteCommandPort;
+
+    @Override
+    public long create(FavoriteVO.save param) {
+        return favoriteCommandPort.create(FavoriteMapper.INSTANCE.favoriteVoSaveToDomain(param));
+    }
+
+    @Override
+    public void update(long id, FavoriteVO.save param) {
+        favoriteCommandPort.update(id, FavoriteMapper.INSTANCE.favoriteVoSaveToDomain(param));
+    }
+
+    @Override
+    public void delete(long id) {
+        favoriteCommandPort.delete(id);
+    }
+}

--- a/src/main/java/com/schedule/share/user/application/service/user/FavoriteWriter.java
+++ b/src/main/java/com/schedule/share/user/application/service/user/FavoriteWriter.java
@@ -28,6 +28,7 @@ public class FavoriteWriter implements FavoriteCommand {
 
     @Override
     public void delete(long id) {
+        favoriteCommandPort.delete(id);
     }
 
     @Override

--- a/src/main/java/com/schedule/share/user/application/service/user/FavoriteWriter.java
+++ b/src/main/java/com/schedule/share/user/application/service/user/FavoriteWriter.java
@@ -7,6 +7,8 @@ import com.schedule.share.user.domain.mapper.FavoriteMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class FavoriteWriter implements FavoriteCommand {
@@ -26,6 +28,11 @@ public class FavoriteWriter implements FavoriteCommand {
 
     @Override
     public void delete(long id) {
-        favoriteCommandPort.delete(id);
     }
+
+    @Override
+    public void delete(List<Long> ids) {
+        favoriteCommandPort.delete(ids);
+    }
+
 }

--- a/src/main/java/com/schedule/share/user/application/service/user/FavoriteWriter.java
+++ b/src/main/java/com/schedule/share/user/application/service/user/FavoriteWriter.java
@@ -22,11 +22,6 @@ public class FavoriteWriter implements FavoriteCommand {
     }
 
     @Override
-    public void update(long id, FavoriteVO.save param) {
-        favoriteCommandPort.update(id, favoriteMapper.favoriteVoSaveToDomain(param));
-    }
-
-    @Override
     public void delete(long id) {
         favoriteCommandPort.delete(id);
     }

--- a/src/main/java/com/schedule/share/user/application/service/user/vo/FavoriteVO.java
+++ b/src/main/java/com/schedule/share/user/application/service/user/vo/FavoriteVO.java
@@ -12,7 +12,7 @@ public class FavoriteVO {
             long userId,
             long scheduleId,
             long calendarId,
-            int isAllday,
+            boolean isAllday,
             LocalDateTime scheduleStartDatetime,
             LocalDateTime scheduleEndDatetime,
             LocalDateTime createdAt
@@ -23,7 +23,7 @@ public class FavoriteVO {
             long userId,
             long scheduleId,
             long calendarId,
-            int isAllday,
+            boolean isAllday,
             LocalDateTime scheduleStartDatetime,
             LocalDateTime scheduleEndDatetime
     ) {}

--- a/src/main/java/com/schedule/share/user/application/service/user/vo/FavoriteVO.java
+++ b/src/main/java/com/schedule/share/user/application/service/user/vo/FavoriteVO.java
@@ -12,7 +12,7 @@ public class FavoriteVO {
             long userId,
             long scheduleId,
             long calendarId,
-            boolean allday,
+            boolean isAllday,
             LocalDateTime scheduleStartDatetime,
             LocalDateTime scheduleEndDatetime,
             LocalDateTime createdAt
@@ -23,7 +23,7 @@ public class FavoriteVO {
             long userId,
             long scheduleId,
             long calendarId,
-            boolean allday,
+            boolean isAllday,
             LocalDateTime scheduleStartDatetime,
             LocalDateTime scheduleEndDatetime
     ) {}

--- a/src/main/java/com/schedule/share/user/application/service/user/vo/FavoriteVO.java
+++ b/src/main/java/com/schedule/share/user/application/service/user/vo/FavoriteVO.java
@@ -12,7 +12,7 @@ public class FavoriteVO {
             long userId,
             long scheduleId,
             long calendarId,
-            boolean isAllday,
+            boolean allday,
             LocalDateTime scheduleStartDatetime,
             LocalDateTime scheduleEndDatetime,
             LocalDateTime createdAt
@@ -23,7 +23,7 @@ public class FavoriteVO {
             long userId,
             long scheduleId,
             long calendarId,
-            boolean isAllday,
+            boolean allday,
             LocalDateTime scheduleStartDatetime,
             LocalDateTime scheduleEndDatetime
     ) {}

--- a/src/main/java/com/schedule/share/user/application/service/user/vo/FavoriteVO.java
+++ b/src/main/java/com/schedule/share/user/application/service/user/vo/FavoriteVO.java
@@ -1,0 +1,30 @@
+package com.schedule.share.user.application.service.user.vo;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+public class FavoriteVO {
+
+    @Builder
+    public record Favorite(
+            long id,
+            long userId,
+            long scheduleId,
+            long calendarId,
+            int isAllday,
+            LocalDateTime scheduleStartDatetime,
+            LocalDateTime scheduleEndDatetime,
+            LocalDateTime createdAt
+    ) {}
+
+    @Builder
+    public record save(
+            long userId,
+            long scheduleId,
+            long calendarId,
+            int isAllday,
+            LocalDateTime scheduleStartDatetime,
+            LocalDateTime scheduleEndDatetime
+    ) {}
+}

--- a/src/main/java/com/schedule/share/user/domain/Favorite.java
+++ b/src/main/java/com/schedule/share/user/domain/Favorite.java
@@ -12,7 +12,7 @@ public class Favorite {
     private long userId;
     private long scheduleId;
     private long calendarId;
-    private boolean allday;
+    private boolean isAllday;
     private LocalDateTime scheduleStartDatetime;
     private LocalDateTime scheduleEndDatetime;
     private LocalDateTime createdAt;

--- a/src/main/java/com/schedule/share/user/domain/Favorite.java
+++ b/src/main/java/com/schedule/share/user/domain/Favorite.java
@@ -12,7 +12,7 @@ public class Favorite {
     private long userId;
     private long scheduleId;
     private long calendarId;
-    private int isAllday;
+    private boolean isAllday;
     private LocalDateTime scheduleStartDatetime;
     private LocalDateTime scheduleEndDatetime;
     private LocalDateTime createdAt;

--- a/src/main/java/com/schedule/share/user/domain/Favorite.java
+++ b/src/main/java/com/schedule/share/user/domain/Favorite.java
@@ -1,0 +1,19 @@
+package com.schedule.share.user.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class Favorite {
+    private long id;
+    private long userId;
+    private long scheduleId;
+    private long calendarId;
+    private int isAllday;
+    private LocalDateTime scheduleStartDatetime;
+    private LocalDateTime scheduleEndDatetime;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/schedule/share/user/domain/Favorite.java
+++ b/src/main/java/com/schedule/share/user/domain/Favorite.java
@@ -12,7 +12,7 @@ public class Favorite {
     private long userId;
     private long scheduleId;
     private long calendarId;
-    private boolean isAllday;
+    private boolean allday;
     private LocalDateTime scheduleStartDatetime;
     private LocalDateTime scheduleEndDatetime;
     private LocalDateTime createdAt;

--- a/src/main/java/com/schedule/share/user/domain/mapper/FavoriteMapper.java
+++ b/src/main/java/com/schedule/share/user/domain/mapper/FavoriteMapper.java
@@ -1,0 +1,21 @@
+package com.schedule.share.user.domain.mapper;
+
+import com.schedule.share.infra.rdb.entity.FavoriteEntity;
+import com.schedule.share.user.application.service.user.vo.FavoriteVO;
+import com.schedule.share.user.domain.Favorite;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface FavoriteMapper {
+
+    FavoriteMapper INSTANCE = Mappers.getMapper(FavoriteMapper.class);
+
+    Favorite favoriteVoSaveToDomain(FavoriteVO.save favorite);
+
+    Favorite favoriteEntityToDomain(FavoriteEntity favoriteEntity);
+
+    FavoriteEntity favoriteToEntity(Favorite favorite);
+
+    FavoriteVO.Favorite favoriteToVO(Favorite favorite);
+}

--- a/src/main/java/com/schedule/share/user/domain/mapper/FavoriteMapper.java
+++ b/src/main/java/com/schedule/share/user/domain/mapper/FavoriteMapper.java
@@ -4,6 +4,7 @@ import com.schedule.share.infra.rdb.entity.FavoriteEntity;
 import com.schedule.share.user.application.service.user.vo.FavoriteVO;
 import com.schedule.share.user.domain.Favorite;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
@@ -11,11 +12,15 @@ public interface FavoriteMapper {
 
     FavoriteMapper INSTANCE = Mappers.getMapper(FavoriteMapper.class);
 
+    @Mapping(source = "isAllday", target = "isAllday")
     Favorite favoriteVoSaveToDomain(FavoriteVO.save favorite);
 
+    @Mapping(source = "allday", target = "isAllday")
     Favorite favoriteEntityToDomain(FavoriteEntity favoriteEntity);
 
+    @Mapping(source = "allday", target = "isAllday")
     FavoriteEntity favoriteToEntity(Favorite favorite);
 
+    @Mapping(source = "allday", target = "isAllday")
     FavoriteVO.Favorite favoriteToVO(Favorite favorite);
 }

--- a/src/main/java/com/schedule/share/user/domain/mapper/FavoriteMapper.java
+++ b/src/main/java/com/schedule/share/user/domain/mapper/FavoriteMapper.java
@@ -5,12 +5,9 @@ import com.schedule.share.user.application.service.user.vo.FavoriteVO;
 import com.schedule.share.user.domain.Favorite;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.factory.Mappers;
 
-@Mapper
+@Mapper(componentModel = "spring")
 public interface FavoriteMapper {
-
-    FavoriteMapper INSTANCE = Mappers.getMapper(FavoriteMapper.class);
 
     @Mapping(source = "isAllday", target = "isAllday")
     Favorite favoriteVoSaveToDomain(FavoriteVO.save favorite);


### PR DESCRIPTION
### PR 요약
- Favorite 도메인 기능 추가

### 변경 사항
- CRUD 추가
- Domain, VO, Entity, Mapper 추가
- Command, Query 추가  
- Port, Adaptor, Service 추가

### 주의 깊게 봐야할 곳
- infra/rdb/entity/FavoriteEntity
  - 기존 `isAllday` 멤버명을 `allday`로 변경하였습니다.
  - 바꾼 이유
    - `isAllday`의 경우, mapstruct에서 `isIsAllday`로 인식해 매핑이 안되는 문제가 발생해 `is`를 제거하였습니다.
```
    @Column(name = "is_allday")
    private boolean allday;
```

### 테스트 방법
- Swagger

### 테스트 결과
#### CREATE
<img width="1370" alt="image" src="https://github.com/user-attachments/assets/bcc56f16-f3aa-4fac-bca9-eda4faa315f2">

#### READ (단일 조회)
<img width="1387" alt="image" src="https://github.com/user-attachments/assets/5da9fef4-8d30-4c24-bbd2-35a59a18d89b">

#### READ (모두 조회)
<img width="1383" alt="image" src="https://github.com/user-attachments/assets/5e5824d7-6e7d-42a7-ae75-c05ff1c523ab">

#### UPDATE
<img width="1389" alt="image" src="https://github.com/user-attachments/assets/0e138657-55ac-4813-89bc-e76b18fdce24">

#### DELETE
<img width="1388" alt="image" src="https://github.com/user-attachments/assets/1bc8bc9c-d38d-41a7-b9b9-4155e8305dbe">

